### PR TITLE
Develop

### DIFF
--- a/src/core/_scaffolding.scss
+++ b/src/core/_scaffolding.scss
@@ -19,6 +19,8 @@
 html {
     font-size: 10px;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    -webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 body {

--- a/src/core/_scaffolding.scss
+++ b/src/core/_scaffolding.scss
@@ -20,7 +20,7 @@ html {
     font-size: 10px;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     -webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 body {


### PR DESCRIPTION
It's is a simple change but with a substantial improvement for macOS browsers. 

**Reference** 
- https://davidwalsh.name/font-smoothing
- https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth

**Before / After**
![image](https://user-images.githubusercontent.com/5122156/42099460-c29e2236-7bbd-11e8-9581-c61b06b9721f.png) 
![image](https://user-images.githubusercontent.com/5122156/42099470-c95046e0-7bbd-11e8-8782-a3e8fa2f2ea7.png)



